### PR TITLE
Add feedback for current project

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>bird-flocks</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/BirdFinder.java
+++ b/BirdFinder.java
@@ -8,52 +8,53 @@ import java.util.List;
 import java.util.Set;
 
 public class BirdFinder {
-	private int BLACK = Color.BLACK.getRGB();
+	private static int BLACK = Color.BLACK.getRGB();
+	private int noiseReduction;
 
-	private BufferedImage binaryImage;
-
-	public BirdFinder(BufferedImage binaryImage) {
-		this.binaryImage = MainController.binaryImage;
+	public BirdFinder(int noiseReduction) {
+		this.noiseReduction = noiseReduction;
 	}
 
-	public BufferedImage outlineBirds(BufferedImage toOutline) {
-		UnionFind uf = new UnionFind(binaryImage.getWidth() * binaryImage.getHeight());
+	public BufferedImage outlineBirds(BufferedImage binaryImage, BufferedImage toOutline) {
+		UnionFind uf = new UnionFind(toOutline.getWidth() * toOutline.getHeight());
 		Graphics toOutlineGraphics = toOutline.getGraphics();
-
+		int iw = binaryImage.getWidth();
+		
 		for (int y = 0; y < binaryImage.getHeight(); y++) {
 			for (int x = 0; x < binaryImage.getWidth(); x++) {
 				if (binaryImage.getRGB(x, y) != BLACK) {
 					continue;
 				}
+				int pixelId = getPixelId(iw, x, y);
 				if (x > 0 && binaryImage.getRGB(x - 1, y) == BLACK) {
-					uf.union(getPixelId(x, y), getPixelId(x - 1, y));
+					uf.union(pixelId, getPixelId(iw, x - 1, y));
 				}
 				if (y > 0 && binaryImage.getRGB(x, y - 1) == BLACK) {
-					uf.union(getPixelId(x, y), getPixelId(x, y - 1));
+					uf.union(pixelId, getPixelId(iw, x, y - 1));
 				}
 				if (y < binaryImage.getHeight() - 1 && binaryImage.getRGB(x, y + 1) == BLACK) {
-					uf.union(getPixelId(x, y), getPixelId(x, y + 1));
+					uf.union(pixelId, getPixelId(iw, x, y + 1));
 				}
 				if (x < binaryImage.getWidth() - 1 && binaryImage.getRGB(x + 1, y) == BLACK) {
-					uf.union(getPixelId(x, y), getPixelId(x + 1, y));
+					uf.union(pixelId, getPixelId(iw, x + 1, y));
 				}
 				if (x > 0 && y > 0 && binaryImage.getRGB(x - 1, y - 1) == BLACK) {
-					uf.union(getPixelId(x, y), getPixelId(x - 1, y - 1));
+					uf.union(pixelId, getPixelId(iw, x - 1, y - 1));
 				}
 				if (x > 0 && y < binaryImage.getHeight() - 1 && binaryImage.getRGB(x - 1, y + 1) == BLACK) {
-					uf.union(getPixelId(x, y), getPixelId(x - 1, y + 1));
+					uf.union(pixelId, getPixelId(iw, x - 1, y + 1));
 				}
 				if (x < binaryImage.getWidth() - 1 && y < binaryImage.getHeight() - 1
 						&& binaryImage.getRGB(x + 1, y + 1) == BLACK) {
-					uf.union(getPixelId(x, y), getPixelId(x + 1, y + 1));
+					uf.union(pixelId, getPixelId(iw, x + 1, y + 1));
 				}
 				if (x < binaryImage.getWidth() - 1 && y > 0 && binaryImage.getRGB(x + 1, y - 1) == BLACK) {
-					uf.union(getPixelId(x, y), getPixelId(x + 1, y - 1));
+					uf.union(pixelId, getPixelId(iw, x + 1, y - 1));
 				}
 			}
 		}
 
-		Set<Integer> roots = uf.getRoots(1);
+		Set<Integer> roots = uf.getRoots(this.noiseReduction);
 		Iterator<Integer> rootIter = roots.iterator();
 		while (rootIter.hasNext()) {
 			int root = rootIter.next();
@@ -63,10 +64,10 @@ public class BirdFinder {
 			int rightmostX = -1;
 			int topmostY = -1;
 			int bottommostY = -1;
-
+			
 			for (int i = 0; i < nodes.size(); i++) {
-				int nodeX = (int) binaryImage.getWidth() % nodes.get(i);
-				int nodeY = (int) binaryImage.getWidth() / nodes.get(i);
+				int nodeX = (int) nodes.get(i) % binaryImage.getWidth();
+				int nodeY = (int) nodes.get(i) / binaryImage.getWidth();
 
 				if (leftmostX == -1 || nodeX < leftmostX) {
 					leftmostX = nodeX;
@@ -90,8 +91,8 @@ public class BirdFinder {
 		return toOutline;
 	}
 
-	private int getPixelId(int x, int y) {
-		return (binaryImage.getWidth() * y) + x;
+	private int getPixelId(int imageWidth, int x, int y) {
+		return (imageWidth * y) + x;
 	}
 
 }

--- a/MainController.java
+++ b/MainController.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import javax.imageio.ImageIO;
 
 import javafx.application.Application;
+import javafx.application.Platform;
 import javafx.embed.swing.SwingFXUtils;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
@@ -17,10 +18,7 @@ import javafx.stage.FileChooser;
 public class MainController {
 	private static FileChooser fileChooser = new FileChooser();
 	private static BlackAndWhiteFilter bwFilter = new BlackAndWhiteFilter(127);
-	public static BufferedImage selectedImage;
-	public static BufferedImage binaryImage;
-	public static BufferedImage birdImage;
-	private static BirdFinder boxFilter = new BirdFinder(binaryImage);
+	private static BirdFinder boxFilter = new BirdFinder(1);
 	
 	@FXML
 	private MenuItem openButton;
@@ -39,7 +37,7 @@ public class MainController {
 
 	@FXML
 	void onClose(ActionEvent event) {
-
+		Platform.exit();
 	}
 
 	@FXML
@@ -51,12 +49,12 @@ public class MainController {
 		}
 
 		try {
-			selectedImage = ImageIO.read(imageFile);
-			binaryImage = bwFilter.applyToImage(selectedImage);
-			birdImage = boxFilter.outlineBirds(binaryImage);
-
+			BufferedImage selectedImage = ImageIO.read(imageFile);
+			BufferedImage binaryImage = bwFilter.applyToImage(selectedImage);
 			originalImageView.setImage(SwingFXUtils.toFXImage(selectedImage, null));
 			blackAndWhiteImageView.setImage(SwingFXUtils.toFXImage(binaryImage, null));
+			
+			BufferedImage birdImage = boxFilter.outlineBirds(binaryImage, selectedImage);
 			birdsOutlinedView.setImage(SwingFXUtils.toFXImage(birdImage, null));
 		} catch (IOException e) {
 


### PR DESCRIPTION
Some feedback on the current approach.

Feel free to apply these manually to the project. It looks like the full Eclipse project wasn't imported to the repo.

### Referencing `MainController` from `BirdFinder`

https://github.com/daraosullivan/bird-flocks/compare/master...aidenkeating:akeating-feedback?expand=1#diff-499f0cc66c4aa78701750fcb59fbdc09L16

MainController controls the UI of the application, BirdFinder is business logic. UI should invoke business logic, but business logic probably shouldn't have any idea about the interface that's invoking it. If we wanted to use BirdFinder in some command line client, we couldn't with the current version. If we remove any references to the UI in BirdFinder then we have a clear separation between the two classes.

### We don't need to specify all the images as fields

If we want a static BirdFinder, then instead of taking in an image in the constructor we should instead leave that until we want to do the conversion. So let's just take in noise reduction here and pass in the black and white and original image when we call `outlineBirds`.

Also, we don't need to store references to the imported images as we don't use them anywhere at the moment except for when importing them. So we can just declare them in the import function instead. https://github.com/daraosullivan/bird-flocks/compare/master...aidenkeating:akeating-feedback?expand=1#diff-bcb036d65982e785f59cdf70f1d3afd3R52